### PR TITLE
Allow disabling service monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow disabling service monitors via helm value `disabled`.
+
 ## [0.0.2] - 2023-02-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Allow disabling service monitors via helm value `disabled`.
 
+### Fixed
+
+- Fix helm template filenames to match actual content.
+
 ## [0.0.2] - 2023-02-24
 
 ### Changed

--- a/helm/cilium-servicemonitors/templates/cilium-agent.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-agent.yaml
@@ -5,23 +5,24 @@ metadata:
   labels:
     application.giantswarm.io/team: {{ .Values.team }}
     {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
-  name: hubble-relay
+  name: cilium-agent
   namespace: kube-system
 spec:
   endpoints:
-  - honorLabels: true
-    interval: 10s
-    path: /metrics
-    port: metrics
-    relabelings:
-      - sourceLabels:
-          - __meta_kubernetes_pod_node_name
-        targetLabel: node
-        replacement: ${1}
+    - honorLabels: true
+      interval: 10s
+      path: /metrics
+      port: metrics
+      relabelings:
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+          replacement: ${1}
   namespaceSelector:
     matchNames:
-    - kube-system
+      - kube-system
   selector:
     matchLabels:
-      k8s-app: hubble-relay
+      k8s-app: cilium
 {{- end }}

--- a/helm/cilium-servicemonitors/templates/cilium-agent.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-agent.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: hubble-relay
+{{- end }}

--- a/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -19,3 +20,4 @@ spec:
     matchLabels:
       io.cilium/app: operator
       name: cilium-operator
+{{- end }}

--- a/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
@@ -5,19 +5,23 @@ metadata:
   labels:
     application.giantswarm.io/team: {{ .Values.team }}
     {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
-  name: cilium-operator
+  name: hubble-relay
   namespace: kube-system
 spec:
   endpoints:
-  - honorLabels: true
-    interval: 10s
-    path: /metrics
-    port: metrics
+    - honorLabels: true
+      interval: 10s
+      path: /metrics
+      port: metrics
+      relabelings:
+        - sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+          replacement: ${1}
   namespaceSelector:
     matchNames:
-    - kube-system
+      - kube-system
   selector:
     matchLabels:
-      io.cilium/app: operator
-      name: cilium-operator
+      k8s-app: hubble-relay
 {{- end }}

--- a/helm/cilium-servicemonitors/templates/cilium-operator.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-operator.yaml
@@ -4,25 +4,20 @@ kind: ServiceMonitor
 metadata:
   labels:
     application.giantswarm.io/team: {{ .Values.team }}
-    {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
-  name: cilium-agent
+      {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
+  name: cilium-operator
   namespace: kube-system
 spec:
   endpoints:
-  - honorLabels: true
-    interval: 10s
-    path: /metrics
-    port: metrics
-    relabelings:
-    relabelings:
-      - sourceLabels:
-          - __meta_kubernetes_pod_node_name
-        targetLabel: node
-        replacement: ${1}
+    - honorLabels: true
+      interval: 10s
+      path: /metrics
+      port: metrics
   namespaceSelector:
     matchNames:
-    - kube-system
+      - kube-system
   selector:
     matchLabels:
-      k8s-app: cilium
+      io.cilium/app: operator
+      name: cilium-operator
 {{- end }}

--- a/helm/cilium-servicemonitors/templates/cilium-operator.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-operator.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -24,3 +25,4 @@ spec:
   selector:
     matchLabels:
       k8s-app: cilium
+{{- end }}

--- a/helm/cilium-servicemonitors/values.yaml
+++ b/helm/cilium-servicemonitors/values.yaml
@@ -3,3 +3,7 @@ cluster:
     clusterDomain: cluster.local
 
 team: kaas
+
+# During initial tests of cilium in production, we are afraid we might have too many metrics scraped by prometheus.
+# In order to avoid having stability issues, we allow disabling scraping of cilium by setting the disabled flag to true.
+disabled: false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26920

this PR makes it possible to disable cilium scraping by running these commands on the management cluster:

```
echo "disabled: true" >values
kubectl -n <cluster_id> create cm cilium-servicemonitors-user-values --from-file=values
```