### PR TITLE
Drop cilium_node_connectivity_latency_seconds metrics

### DIFF
--- a/helm/cilium-servicemonitors/values.schema.json
+++ b/helm/cilium-servicemonitors/values.schema.json
@@ -2,6 +2,54 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "agent": {
+            "type": "object",
+            "properties": {
+                "metricRelabelings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "action": {
+                                "type": "string"
+                            },
+                            "regex": {
+                                "type": "string"
+                            },
+                            "sourceLabels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "relabelings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "replacement": {
+                                "type": "string"
+                            },
+                            "sourceLabels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "targetLabel": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "scrapeInterval": {
+                    "type": "string"
+                }
+            }
+        },
         "cluster": {
             "type": "object",
             "properties": {
@@ -17,6 +65,51 @@
         },
         "disabled": {
             "type": "boolean"
+        },
+        "hubble": {
+            "type": "object",
+            "properties": {
+                "metricRelabelings": {
+                    "type": "object"
+                },
+                "relabelings": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "replacement": {
+                                "type": "string"
+                            },
+                            "sourceLabels": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "targetLabel": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "scrapeInterval": {
+                    "type": "string"
+                }
+            }
+        },
+        "operator": {
+            "type": "object",
+            "properties": {
+                "metricRelabelings": {
+                    "type": "object"
+                },
+                "relabelings": {
+                    "type": "object"
+                },
+                "scrapeInterval": {
+                    "type": "string"
+                }
+            }
         },
         "team": {
             "type": "string"

--- a/helm/cilium-servicemonitors/values.yaml
+++ b/helm/cilium-servicemonitors/values.yaml
@@ -16,9 +16,15 @@ agent:
     targetLabel: node
     replacement: ${1}
   metricRelabelings:
+  # 'cilium_node_connectivity_latency_seconds' and 'cilium_node_connectivity_status' have too high cardinality
+  # See note in doc: https://docs.cilium.io/en/stable/observability/metrics/#configuration
   - sourceLabels:
     - __name__
     regex: 'cilium_node_connectivity_latency_seconds'
+    action: drop
+  - sourceLabels:
+    - __name__
+    regex: 'cilium_node_connectivity_status'
     action: drop
 hubble:
   scrapeInterval: 60s

--- a/helm/cilium-servicemonitors/values.yaml
+++ b/helm/cilium-servicemonitors/values.yaml
@@ -15,8 +15,11 @@ agent:
     - __meta_kubernetes_pod_node_name
     targetLabel: node
     replacement: ${1}
-  metricRelabelings: {}
-
+  metricRelabelings:
+  - sourceLabels:
+    - __name__
+    regex: 'cilium_node_connectivity_latency_seconds'
+    action: drop
 hubble:
   scrapeInterval: 60s
   relabelings:


### PR DESCRIPTION
* drop cilium_node_connectivity_latency_seconds metrics
    * No reference found in `prometheus-rules`
    * No reference found in `dashboards`
* increase scrapeInterval (aligned to agent's default)
* update values schema

Tested on an overloaded cluster (`anteater / seu01`), seriously decreased memory usage.
![image](https://github.com/giantswarm/cilium-servicemonitors-app/assets/12008875/47fc9b08-b054-4dcd-9242-ee80c0d05028)

Reference incidents: 
* [#inc-2023-06-30-anteater-seu01-prometheusavailabilityratio](https://gigantic.slack.com/archives/C05FPN3U0QY)
* [#inc-2023-07-04-anteater-deu01-prometheusavailabilityratio](https://gigantic.slack.com/archives/C05G5FVT0AC)

BTW, I don't know who's responsible for this repo so I added random people who already contributed.