### PR TITLE
Increase logging-interval

### DIFF
--- a/helm/cilium-servicemonitors/templates/cilium-agent.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-agent.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
   - honorLabels: true
-    interval: 10s
+    interval: {{ .Values.agent.scrapeInterval }}
     path: /metrics
     port: metrics
     {{- if .Values.agent.metricRelabelings }}

--- a/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
   - honorLabels: true
-    interval: 10s
+    interval: {{ .Values.hubble.scrapeInterval }}
     path: /metrics
     port: metrics
     {{- if .Values.hubble.metricRelabelings }}

--- a/helm/cilium-servicemonitors/templates/cilium-operator.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-operator.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   endpoints:
   - honorLabels: true
-    interval: 10s
+    interval: {{ .Values.operator.scrapeInterval }}
     path: /metrics
     port: metrics
     {{- if .Values.operator.metricRelabelings }}

--- a/helm/cilium-servicemonitors/values.yaml
+++ b/helm/cilium-servicemonitors/values.yaml
@@ -9,6 +9,7 @@ team: kaas
 disabled: false
 
 agent:
+  scrapeInterval: 60s
   relabelings:
   - sourceLabels:
     - __meta_kubernetes_pod_node_name
@@ -17,6 +18,7 @@ agent:
   metricRelabelings: {}
 
 hubble:
+  scrapeInterval: 60s
   relabelings:
     - sourceLabels:
       - __meta_kubernetes_pod_node_name
@@ -25,5 +27,6 @@ hubble:
   metricRelabelings: {}
 
 operator:
+  scrapeInterval: 60s
   relabelings: {}
   metricRelabelings: {}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27490

Aligns to our default scraping interval.
Will:
- reduce overal Prometheus disk usage
- reduce Promtheus WAL size
- improve Prometheus startup time
- may reduce a bit of Prometheus RAM usage

Bad effects:
- less data points