### PR TITLE
Drop greedy metrics and increase scrape interval to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- Drop greedy metrics and increase scrape interval to 60s.
+- Drop greedy metrics `cilium_node_connectivity_latency_seconds` and `cilium_node_connectivity_status`.
+- Increase scrape interval to 60s.
 
 ## [0.1.1] - 2023-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop greedy metrics and increase scrape interval to 60s.
+
 ## [0.1.1] - 2023-05-16
 
 ### Added


### PR DESCRIPTION
Update changelog following those 2 PR:

* https://github.com/giantswarm/cilium-servicemonitors-app/pull/7
* https://github.com/giantswarm/cilium-servicemonitors-app/pull/8