### PR TITLE
feat: switch monitors from ServiceMonitor to PodMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add per-monitor `enabled` flag for the agent, hubble and operator.
+
 ### Changed
 
 - Switch all monitors from ServiceMonitor to PodMonitor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Switch all monitors from ServiceMonitor to PodMonitor.
+
 ## [0.1.4] - 2026-02-19
 
 ### Changed

--- a/helm/cilium-servicemonitors/templates/cilium-agent.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-agent.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.disabled }}
+{{- if and (not .Values.disabled) .Values.agent.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/helm/cilium-servicemonitors/templates/cilium-agent.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-agent.yaml
@@ -1,17 +1,17 @@
 {{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   labels:
     {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
   name: cilium-agent
   namespace: kube-system
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - honorLabels: true
     interval: {{ .Values.agent.scrapeInterval }}
     path: /metrics
-    port: metrics
+    port: prometheus
     {{- if .Values.agent.metricRelabelings }}
     metricRelabelings:
     {{- tpl (toYaml .Values.agent.metricRelabelings | nindent 4) . }}

--- a/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
@@ -1,17 +1,17 @@
 {{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   labels:
     {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
   name: hubble-relay
   namespace: kube-system
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - honorLabels: true
     interval: {{ .Values.hubble.scrapeInterval }}
     path: /metrics
-    port: metrics
+    port: prometheus
     {{- if .Values.hubble.metricRelabelings }}
     metricRelabelings:
     {{- tpl (toYaml .Values.hubble.metricRelabelings | nindent 4) . }}

--- a/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-hubble.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.disabled }}
+{{- if and (not .Values.disabled) .Values.hubble.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/helm/cilium-servicemonitors/templates/cilium-operator.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-operator.yaml
@@ -1,17 +1,17 @@
 {{- if not .Values.disabled }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   labels:
     {{- include "cilium-servicemonitors.labels" . | nindent 4 }}
   name: cilium-operator
   namespace: kube-system
 spec:
-  endpoints:
+  podMetricsEndpoints:
   - honorLabels: true
     interval: {{ .Values.operator.scrapeInterval }}
     path: /metrics
-    port: metrics
+    port: prometheus
     {{- if .Values.operator.metricRelabelings }}
     metricRelabelings:
     {{- tpl (toYaml .Values.operator.metricRelabelings | nindent 4) . }}

--- a/helm/cilium-servicemonitors/templates/cilium-operator.yaml
+++ b/helm/cilium-servicemonitors/templates/cilium-operator.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.disabled }}
+{{- if and (not .Values.disabled) .Values.operator.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/helm/cilium-servicemonitors/values.schema.json
+++ b/helm/cilium-servicemonitors/values.schema.json
@@ -5,6 +5,9 @@
         "agent": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "metricRelabelings": {
                     "type": "array",
                     "items": {
@@ -69,6 +72,9 @@
         "hubble": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "metricRelabelings": {
                     "type": "object"
                 },
@@ -100,6 +106,9 @@
         "operator": {
             "type": "object",
             "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
                 "metricRelabelings": {
                     "type": "object"
                 },

--- a/helm/cilium-servicemonitors/values.yaml
+++ b/helm/cilium-servicemonitors/values.yaml
@@ -7,6 +7,7 @@ cluster:
 disabled: false
 
 agent:
+  enabled: true
   scrapeInterval: 60s
   relabelings:
   - sourceLabels:
@@ -21,6 +22,7 @@ agent:
     regex: cilium_(node_connectivity_latency_seconds|node_connectivity_status|k8s_client_api_latency_time_seconds_bucket|agent_api_process_time_seconds_bucket|policy_regeneration_time_stats_seconds_bucket)
     action: drop
 hubble:
+  enabled: true
   scrapeInterval: 60s
   relabelings:
     - sourceLabels:
@@ -30,6 +32,7 @@ hubble:
   metricRelabelings: {}
 
 operator:
+  enabled: true
   scrapeInterval: 60s
   relabelings: {}
   metricRelabelings: {}


### PR DESCRIPTION
Some clusters lack the Services needed for scraping metrics. This switches all monitors in this chart from `ServiceMonitor` to `PodMonitor` so the Cilium agent, operator and hubble-relay pods are scraped directly.

Key detail: a PodMonitor endpoint `port` references the **container** port name, so the endpoint now uses `prometheus` instead of the Service port name `metrics`. Verified against live clusters:
- agent: pod label `k8s-app: cilium`, container port `prometheus`
- operator: pod labels `io.cilium/app: operator` + `name: cilium-operator`, container port `prometheus` (9963)
- hubble-relay: pod label `k8s-app: hubble-relay`, container port `prometheus` (9966)

Scrape intervals, relabelings and `honorLabels` are unchanged.

Towards https://github.com/giantswarm/giantswarm/issues/37208
